### PR TITLE
Add .gitignore for common notebook artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Ignore Python bytecode files
+*.py[cod]
+__pycache__/
+
+# Ignore Jupyter notebook checkpoints
+.ipynb_checkpoints/
+
+# Ignore temporary files
+*~
+*.swp
+*.tmp


### PR DESCRIPTION
## Summary
- add .gitignore at repo root to avoid committing compiled Python artifacts, Jupyter notebook checkpoints, and temporary files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68400d0ce6748332b43499ed6705ffc8